### PR TITLE
Add geolocation weather, PWA setup, and GitHub Pages prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # cloc
-cloc is a simple clock and weather app
+
+cloc is a simple clock and weather app.
+
+## Features
+- Displays local time and Eastern Time.
+- Shows the current date.
+- Fetches weather using the browser's location when available, with a San Diego fallback.
+- Includes a basic PWA manifest and service worker.
+
+## GitHub Pages
+- Static assets use relative paths for compatibility with GitHub Pages hosting.
+- To deploy, enable GitHub Pages on the repository root and ensure this project is served from that branch.

--- a/app.js
+++ b/app.js
@@ -3,7 +3,7 @@ function updateTime() {
     const now = new Date();
 
     const estTime = new Date(now.toLocaleString('en-US', { timeZone: 'America/New_York' }));
-    
+
     const hours = now.getHours() % 12 || 12;
     const minutes = String(now.getMinutes()).padStart(2, '0');
     const timeString = `${hours}:${minutes}`;
@@ -33,21 +33,47 @@ function updateDate() {
 setInterval(updateDate, 1000);
 
 const apiKey = 'cee34975e4bf84d0c080f6a443c26ebc'; // Replace with your OpenWeatherMap API key
-const city = 'San Diego'; // Replace with the name of the city you want to get weather information for
-const apiUrl = `https://api.openweathermap.org/data/2.5/weather?q=${city}&appid=${apiKey}&units=imperial`;
 
-// Fetch the weather data from the OpenWeatherMap API
-fetch(apiUrl)
-  .then(response => response.json())
-  .then(data => {
-    // Update the weather icon
+function updateWeather(data) {
     const iconCode = data.weather[0].icon;
     const iconUrl = `https://openweathermap.org/img/wn/${iconCode}.png`;
     document.getElementById('weather-icon').src = iconUrl;
     document.getElementById('weather-icon').alt = data.weather[0].description;
 
-    // Update the temperature
     const temp = Math.round(data.main.temp);
     document.getElementById('weather-temp').textContent = `${temp}°F`;
-  })
-  .catch(error => console.log(error));
+}
+
+function fetchWeather(url) {
+    fetch(url)
+        .then(response => response.json())
+        .then(updateWeather)
+        .catch(error => console.log(error));
+}
+
+function initWeather() {
+    if (navigator.geolocation) {
+        navigator.geolocation.getCurrentPosition(
+            position => {
+                const { latitude, longitude } = position.coords;
+                const apiUrl = `https://api.openweathermap.org/data/2.5/weather?lat=${latitude}&lon=${longitude}&appid=${apiKey}&units=imperial`;
+                fetchWeather(apiUrl);
+            },
+            () => {
+                const city = 'San Diego';
+                const apiUrl = `https://api.openweathermap.org/data/2.5/weather?q=${city}&appid=${apiKey}&units=imperial`;
+                fetchWeather(apiUrl);
+            }
+        );
+    } else {
+        const city = 'San Diego';
+        const apiUrl = `https://api.openweathermap.org/data/2.5/weather?q=${city}&appid=${apiKey}&units=imperial`;
+        fetchWeather(apiUrl);
+    }
+}
+
+initWeather();
+
+if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('service-worker.js').catch(error => console.log(error));
+}

--- a/index.html
+++ b/index.html
@@ -1,21 +1,20 @@
-<!-- 
+<!--
 Project: cloc
 Author: Ben Steward
-Date: 2023-04-28 
+Date: 2023-04-28
 Revised: 2023-04-30
 -->
 
-<!-- TODO 
+<!-- TODO
  - [ ] Add settings menu
  - [ ] Add option to change color
- - [ ] Capture location for weather 
+ - [x] Capture location for weather
  - [ ] Change weather icon theme
  - [ ] Create PWA icon
- - [ ] Add PWA manifest
- - [ ] Add PWA service worker
+ - [x] Add PWA manifest
+ - [x] Add PWA service worker
  - [ ] Add fallback icon for weather
- - [ ] 
-
+ - [ ]
 -->
 
 <!DOCTYPE html>
@@ -30,6 +29,7 @@ Revised: 2023-04-30
     <style>
         @import url(style.css);
     </style>
+    <link rel="manifest" href="manifest.json">
     <script src="app.js"></script>
 </head>
 
@@ -47,7 +47,7 @@ Revised: 2023-04-30
             <img src="cog.svg" alt="Settings icon">
         </div> <!-- end #settings -->
         <div id="weather">
-            <img id="weather-icon" src="" alt="">
+            <img id="weather-icon" src="https://openweathermap.org/img/wn/01d.png" alt="Weather icon placeholder">
             <span id="weather-temp"></span>
         </div><!-- end #weather -->
     </div><!-- end .container -->

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,15 @@
+{
+  "name": "cloc",
+  "short_name": "cloc",
+  "start_url": "./",
+  "display": "standalone",
+  "background_color": "#000000",
+  "theme_color": "#000000",
+  "icons": [
+    {
+      "src": "cog.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,21 @@
+const CACHE_NAME = 'cloc-cache-v1';
+const ASSETS = [
+  './',
+  './index.html',
+  './style.css',
+  './app.js',
+  './cog.svg',
+  './manifest.json'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- Fetch weather using browser geolocation with San Diego fallback
- Add PWA manifest, service worker, and registration
- Prepare static assets for GitHub Pages and document deployment

## Testing
- `npx -y htmlhint index.html`
- `node --check app.js`
- `node --check service-worker.js`


------
https://chatgpt.com/codex/tasks/task_e_68b60ce1f23c8327ab82196fdefcd6fe